### PR TITLE
 Track clonal lineage via `SubClone::parent_id` and save to `variant_phylogeny` folder

### DIFF
--- a/output.md
+++ b/output.md
@@ -35,16 +35,26 @@ test/
 │   │   │   ├── 1.json
 │   │   │   └── ...
 │   │   └── ...
-│   └── variant_fraction # the subclones' abbundance
-│       ├── 0dot0years
-│       │   ├── 0.csv
-│       │   ├── 1.csv
-│       │   └── ...
-│       ├── 1dot0years
-│       │   ├── 0.csv
-│       │   ├── 1.csv
-│       │   └── ...
-│       └── ...
+│   ├── variant_fraction # the subclones' abbundance
+│   │    ├── 0dot0years
+│   │    │   ├── 0.csv
+│   │    │   ├── 1.csv
+│   │    │   └── ...
+│   │    ├── 1dot0years
+│   │    │   ├── 0.csv
+│   │    │   ├── 1.csv
+│   │    │   └── ...
+│   │    └── ...
+│   ├── variant_phylogeny # the subclones' parent_id
+│   │    ├── 0dot0years
+│   │    │   ├── 0.csv
+│   │    │   ├── 1.csv
+│   │    │   └── ...
+│   │    ├── 1dot0years
+│   │    │   ├── 0.csv
+│   │    │   ├── 1.csv
+│   │    │   └── ...
+│   └    └── ...
 └── rates
     ├── 0.csv
     ├── 1.csv
@@ -60,5 +70,8 @@ More info about the folders generated as the output of `hsc`:
 - **`mutations`:** folder containing a parquet files representing the number of cells carrying the mutations present in the population,
 - **`sfs`:** folder containing json files with keys being the jcells (x-axis) and values being the number of variants with jcells (y-axis),
 - **`variant_fraction`**: folder containing csv files with the abbundance of all subclones, where the first entry represents the frequency of the wild-type clone with `b0` birth-rate,
+- **`variant_phylogeny`**: folder containing csv files with the `parent_id` of all subclones — entry *i* is the id of the subclone that the cells in slot *i* descend from (set when a fit-mutation event placed them there).
+Slots that were never repopulated, including the wild-type clone (slot 0), have `parent_id = 0`.
+Note: as `parent_id` is a clone-level (no cell-level) property, when the snapshot is a subsample, `variant_phylogeny` always reflects the full-population lineage, and thus we can have `variant_phylogeny[i] != 0` even when `variant_fractions[i] = 0`.
 - **`rates`:** folder containing the csv files with the birth-rates of the subclones, where the first entry represents the birth-rate of the wild-type `b0`.
 

--- a/output.md
+++ b/output.md
@@ -71,7 +71,7 @@ More info about the folders generated as the output of `hsc`:
 - **`sfs`:** folder containing json files with keys being the jcells (x-axis) and values being the number of variants with jcells (y-axis),
 - **`variant_fraction`**: folder containing csv files with the abbundance of all subclones, where the first entry represents the frequency of the wild-type clone with `b0` birth-rate,
 - **`variant_phylogeny`**: folder containing csv files with the `parent_id` of all subclones — entry *i* is the id of the subclone that the cells in slot *i* descend from (set when a fit-mutation event placed them there).
-Slots that were never repopulated, including the wild-type clone (slot 0), have `parent_id = 0`.
-Note: as `parent_id` is a clone-level (no cell-level) property, when the snapshot is a subsample, `variant_phylogeny` always reflects the full-population lineage, and thus we can have `variant_phylogeny[i] != 0` even when `variant_fractions[i] = 0`.
+The wild-type clone (slot 0) has `parent_id = None` because it has no parent. Every other slot defaults to `0` (descended from the wild-type clone) until a fit-mutation event reassigns it.
+Note: as `parent_id` is a clone-level (not cell-level) property, when the snapshot is a subsample, `variant_phylogeny` always reflects the full-population lineage, and thus we can have `variant_phylogeny[i] != None` even when `variant_fractions[i] = 0`.
 - **`rates`:** folder containing the csv files with the birth-rates of the subclones, where the first entry represents the birth-rate of the wild-type `b0`.
 

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -27,6 +27,7 @@ pub enum Stats {
     Burden,
     ScBurden,
     Variants,
+    VariantPhylogeny,
 }
 
 impl From<Stats> for Stats2Save {
@@ -36,6 +37,7 @@ impl From<Stats> for Stats2Save {
             Stats::Sfs => Stats2Save::Sfs,
             Stats::ScBurden => Stats2Save::SingleCellMutations,
             Stats::Variants => Stats2Save::VariantFraction,
+            Stats::VariantPhylogeny => Stats2Save::VariantPhylogeny,
         }
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -258,7 +258,7 @@ impl Moran {
         // remove a cell from a random subclone based on the frequencies of
         // the clones at the current state
         let variants = Variants::variant_counts(&self.subclones);
-        let id2remove = WeightedIndex::new(variants).unwrap().sample(rng);
+        let id2remove = WeightedIndex::new(variants).unwrap().sample(rng) as CloneId;
         let _ = self
             .subclones
             .get_mut_clone_unchecked(id2remove)
@@ -671,7 +671,8 @@ mod tests {
         //!
         //! **warning** this is very slow.
         let tot_cells = subclones.compute_tot_cells();
-        (0..MAX_SUBCLONES).find(|&id| subclones.get_clone(id).unwrap().cell_count() == tot_cells)
+        (0..MAX_SUBCLONES as CloneId)
+            .find(|&id| subclones.get_clone(id).unwrap().cell_count() == tot_cells)
     }
 
     #[quickcheck]

--- a/src/process.rs
+++ b/src/process.rs
@@ -291,6 +291,7 @@ impl Moran {
                 &self.filename,
                 time,
                 population,
+                &self.subclones,
                 &self.stats,
             )
             .with_context(|| "cannot save the full population")
@@ -305,6 +306,7 @@ impl Moran {
                         &self.filename,
                         time,
                         population,
+                        &self.subclones,
                         &self.stats,
                     )
                     .with_context(|| "cannot save the full population")
@@ -319,6 +321,7 @@ impl Moran {
                     &self.filename,
                     time,
                     cells_with_idx,
+                    &self.subclones,
                     &self.stats,
                 )
                 .with_context(|| "cannot save the subsample")

--- a/src/proliferation.rs
+++ b/src/proliferation.rs
@@ -249,7 +249,7 @@ mod tests {
 
         proliferation.proliferate(&mut subclones, 2.0, 0, &distributions, rng);
 
-        let target = (1..crate::MAX_SUBCLONES)
+        let target = (1..crate::MAX_SUBCLONES as CloneId)
             .find(|&i| !subclones.get_clone(i).unwrap().is_empty())
             .expect("new variant should have populated some clone other than 0");
         assert_eq!(
@@ -268,7 +268,7 @@ mod tests {
 
         proliferation.proliferate(&mut subclones, 1.0, 0, &make_distributions(), rng);
 
-        for i in 0..crate::MAX_SUBCLONES {
+        for i in 0..crate::MAX_SUBCLONES as CloneId {
             let expected = if i == 0 { None } else { Some(0) };
             assert_eq!(subclones.get_clone(i).unwrap().get_parent_id(), expected);
         }

--- a/src/proliferation.rs
+++ b/src/proliferation.rs
@@ -252,7 +252,10 @@ mod tests {
         let target = (1..crate::MAX_SUBCLONES)
             .find(|&i| !subclones.get_clone(i).unwrap().is_empty())
             .expect("new variant should have populated some clone other than 0");
-        assert_eq!(subclones.get_clone(target).unwrap().get_parent_id(), 0);
+        assert_eq!(
+            subclones.get_clone(target).unwrap().get_parent_id(),
+            Some(0)
+        );
     }
 
     #[test]
@@ -266,7 +269,8 @@ mod tests {
         proliferation.proliferate(&mut subclones, 1.0, 0, &make_distributions(), rng);
 
         for i in 0..crate::MAX_SUBCLONES {
-            assert_eq!(subclones.get_clone(i).unwrap().get_parent_id(), 0);
+            let expected = if i == 0 { None } else { Some(0) };
+            assert_eq!(subclones.get_clone(i).unwrap().get_parent_id(), expected);
         }
     }
 

--- a/src/proliferation.rs
+++ b/src/proliferation.rs
@@ -112,6 +112,13 @@ impl Proliferation {
                 .get_mut_clone_unchecked(clone_id)
                 .assign_cell(stem_cell);
         }
+        if clone_id != proliferating_subclone {
+            // next_clone returns a different id only when a new fit variant
+            // is sampled into a previously-empty slot — record the lineage.
+            subclones
+                .get_mut_clone_unchecked(clone_id)
+                .set_parent_id(proliferating_subclone);
+        }
     }
 
     pub fn realise_background_mutations(
@@ -227,6 +234,40 @@ mod tests {
             .map(|c| c.burden())
             .sum();
         assert!(total > 0);
+    }
+
+    #[test]
+    fn parent_id_set_on_new_variant() {
+        // Probs::new computes u = mu / cells = 50/100 = 0.5. With
+        // interdivision_time = time - last_division_t = 2.0, the proliferation
+        // probability p = u * 2.0 = 1.0, so next_clone always picks a new
+        // empty target. The new target's parent_id must be the source (0).
+        let rng = &mut ChaCha8Rng::seed_from_u64(7);
+        let mut subclones = make_subclones(5, 0.0);
+        let distributions = Distributions::new(Probs::new(50., 50., 50., 0., 100));
+        let proliferation = Proliferation::new(NeutralMutations::UponDivision, Division::Symmetric);
+
+        proliferation.proliferate(&mut subclones, 2.0, 0, &distributions, rng);
+
+        let target = (1..crate::MAX_SUBCLONES)
+            .find(|&i| !subclones.get_clone(i).unwrap().is_empty())
+            .expect("new variant should have populated some clone other than 0");
+        assert_eq!(subclones.get_clone(target).unwrap().get_parent_id(), 0);
+    }
+
+    #[test]
+    fn parent_id_untouched_without_new_variant() {
+        // last_division_t = time ⇒ interdivision_time = 0 ⇒ p = 0, so
+        // next_clone returns the source clone and no parent_id is written.
+        let rng = &mut ChaCha8Rng::seed_from_u64(7);
+        let mut subclones = make_subclones(5, 1.0);
+        let proliferation = Proliferation::new(NeutralMutations::UponDivision, Division::Symmetric);
+
+        proliferation.proliferate(&mut subclones, 1.0, 0, &make_distributions(), rng);
+
+        for i in 0..crate::MAX_SUBCLONES {
+            assert_eq!(subclones.get_clone(i).unwrap().get_parent_id(), 0);
+        }
     }
 
     #[test]

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -15,7 +15,7 @@ use log::debug;
 use crate::{
     genotype::{MutationalBurden, Sfs, SingleCellMutations},
     stemcell::StemCell,
-    subclone::{save_variant_fraction, save_variant_phylogeny, SubClones},
+    subclone::{save_variant_fraction, save_variant_phylogeny, CloneId, SubClones},
 };
 
 /// The statistics/measurements we want to save from the simulations.
@@ -109,7 +109,7 @@ pub(crate) fn save_it(
     path2dir: &Path,
     filename: &Path,
     time: f32,
-    cells_with_idx: Vec<(&StemCell, usize)>,
+    cells_with_idx: Vec<(&StemCell, CloneId)>,
     subclones: &SubClones,
     stats: &StatsConfig,
 ) -> anyhow::Result<()> {
@@ -182,7 +182,7 @@ pub(crate) fn save_it(
                 cells_with_idx
                     .into_iter()
                     .map(|(cell, id)| (cell.to_owned(), id))
-                    .collect::<Vec<(StemCell, usize)>>(),
+                    .collect::<Vec<(StemCell, CloneId)>>(),
             ),
             &make_path(
                 path2dir,

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -15,7 +15,7 @@ use log::debug;
 use crate::{
     genotype::{MutationalBurden, Sfs, SingleCellMutations},
     stemcell::StemCell,
-    subclone::{save_variant_fraction, SubClones},
+    subclone::{save_variant_fraction, save_variant_phylogeny, SubClones},
 };
 
 /// The statistics/measurements we want to save from the simulations.
@@ -24,6 +24,7 @@ pub enum Stats2Save {
     Burden,
     Sfs,
     VariantFraction,
+    VariantPhylogeny,
     SingleCellMutations,
 }
 
@@ -92,6 +93,7 @@ fn make_path(
         // only one file for the single cell mutational burden
         Stats2Save::SingleCellMutations => path2dir.join("mutations"),
         Stats2Save::VariantFraction => path2dir.join("variant_fraction"),
+        Stats2Save::VariantPhylogeny => path2dir.join("variant_phylogeny"),
         Stats2Save::Burden => path2dir.join("burden"),
         Stats2Save::Sfs => path2dir.join("sfs"),
     };
@@ -108,6 +110,7 @@ pub(crate) fn save_it(
     filename: &Path,
     time: f32,
     cells_with_idx: Vec<(&StemCell, usize)>,
+    subclones: &SubClones,
     stats: &StatsConfig,
 ) -> anyhow::Result<()> {
     debug!("saving data at time {time}");
@@ -185,6 +188,22 @@ pub(crate) fn save_it(
                 path2dir,
                 filename,
                 Stats2Save::VariantFraction,
+                nb_cells,
+                time,
+            )?,
+        )?;
+    }
+
+    if stats.enabled.contains(Stats2Save::VariantPhylogeny) {
+        // parent_id is a clone-level property; subsampling cells does not
+        // change lineage. Always write the full-population view from the live
+        // `subclones`, regardless of `cells_with_idx`.
+        save_variant_phylogeny(
+            subclones,
+            &make_path(
+                path2dir,
+                filename,
+                Stats2Save::VariantPhylogeny,
                 nb_cells,
                 time,
             )?,

--- a/src/subclone.rs
+++ b/src/subclone.rs
@@ -92,6 +92,8 @@ pub type CloneId = usize;
 pub struct SubClone {
     cells: Vec<StemCell>,
     pub id: CloneId,
+    // default is the neutral clone with id 0
+    parent_id: CloneId,
 }
 
 impl Iterator for SubClone {
@@ -107,6 +109,7 @@ impl SubClone {
         SubClone {
             cells: Vec::with_capacity(cell_capacity),
             id,
+            parent_id: 0,
         }
     }
 
@@ -114,11 +117,16 @@ impl SubClone {
         SubClone {
             cells: Vec::with_capacity(capacity),
             id,
+            parent_id: 0,
         }
     }
 
     pub fn empty_with_id(id: usize) -> SubClone {
-        SubClone { cells: vec![], id }
+        SubClone {
+            cells: vec![],
+            id,
+            parent_id: 0,
+        }
     }
 
     pub fn get_mut_cells(&mut self) -> &mut [StemCell] {
@@ -135,6 +143,14 @@ impl SubClone {
 
     pub fn is_empty(&self) -> bool {
         self.get_cells().is_empty()
+    }
+
+    pub fn get_parent_id(&self) -> CloneId {
+        self.parent_id
+    }
+
+    pub fn set_parent_id(&mut self, parent_id: CloneId) {
+        self.parent_id = parent_id;
     }
 
     pub fn assign_cell(&mut self, cell: StemCell) {
@@ -241,6 +257,8 @@ impl SubClones {
 
     pub(crate) fn into_subsampled(self, nb_cells: NonZeroUsize, rng: &mut impl Rng) -> Self {
         //! Take a subsample of the population that is stored in these subclones.
+        let parent_ids: [CloneId; MAX_SUBCLONES] = std::array::from_fn(|i| self.0[i].parent_id);
+
         let mut subclones = Self::new_empty();
 
         for (cell, clone_id) in self
@@ -263,6 +281,16 @@ impl SubClones {
         {
             subclones.0[clone_id].cells.push(cell);
         }
+
+        // `parent_id` is preserved per slot for clones that retain at least
+        // one cell after subsampling: clones that lost all their cells revert
+        // to default which is the neutral clone.
+        for (i, &pid) in parent_ids.iter().enumerate() {
+            if !subclones.0[i].is_empty() {
+                subclones.0[i].parent_id = pid;
+            }
+        }
+
         subclones
     }
 
@@ -439,7 +467,11 @@ mod tests {
 
     #[quickcheck]
     fn assign_cell_test(id: usize) -> bool {
-        let mut neutral_clone = SubClone { cells: vec![], id };
+        let mut neutral_clone = SubClone {
+            cells: vec![],
+            id,
+            parent_id: 0,
+        };
         let cell = StemCell::new();
         assert!(neutral_clone.cells.is_empty());
 

--- a/src/subclone.rs
+++ b/src/subclone.rs
@@ -78,7 +78,12 @@ impl Fitness {
 }
 
 /// Id of the [`SubClone`]s.
-pub type CloneId = usize;
+///
+/// `u16` is wide enough for `MAX_SUBCLONES = 3000` (≪ `u16::MAX = 65535`) and
+/// keeps `Option<CloneId>` at 4 bytes (vs 16 with `usize`), shrinking
+/// `SubClone` accordingly. `usize` is reserved for array-indexing call sites,
+/// which cast at the boundary.
+pub type CloneId = u16;
 
 fn default_parent_id(id: CloneId) -> Option<CloneId> {
     // wild-type has no parent; every other slot is, by default, a child of
@@ -125,7 +130,7 @@ impl SubClone {
         }
     }
 
-    pub fn with_capacity(id: usize, capacity: usize) -> SubClone {
+    pub fn with_capacity(id: CloneId, capacity: usize) -> SubClone {
         SubClone {
             cells: Vec::with_capacity(capacity),
             id,
@@ -133,7 +138,7 @@ impl SubClone {
         }
     }
 
-    pub fn empty_with_id(id: usize) -> SubClone {
+    pub fn empty_with_id(id: CloneId) -> SubClone {
         SubClone {
             cells: vec![],
             id,
@@ -149,7 +154,7 @@ impl SubClone {
         &self.cells
     }
 
-    pub fn get_cells_subclones_idx(&self) -> Vec<(&StemCell, usize)> {
+    pub fn get_cells_subclones_idx(&self) -> Vec<(&StemCell, CloneId)> {
         self.cells.iter().map(|cell| (cell, self.id)).collect()
     }
 
@@ -195,14 +200,14 @@ pub fn next_clone(
     // this will panic when u is not small and the cell hasn't divided much,
     // i.e. when p > 1
     if Bernoulli::new(p).unwrap().sample(rng) {
-        let mut rnd_clone_id = rng.random_range(0..MAX_SUBCLONES);
+        let mut rnd_clone_id = rng.random_range(0..MAX_SUBCLONES) as CloneId;
         let mut counter = 0;
         // the new random clone cannot have `subclone_id` id and must be empty
         while (rnd_clone_id == old_subclone_id
             || !subclones.get_clone(rnd_clone_id).unwrap().is_empty())
             && counter <= MAX_SUBCLONES
         {
-            rnd_clone_id = rng.random_range(0..MAX_SUBCLONES);
+            rnd_clone_id = rng.random_range(0..MAX_SUBCLONES) as CloneId;
             counter += 1;
         }
         assert!(counter <= MAX_SUBCLONES, "max number of clones reached");
@@ -228,7 +233,7 @@ impl SubClones {
         //! All clones have their own `capacity`.
         // initial state
         let mut subclones: Box<[SubClone]> = (0..MAX_SUBCLONES)
-            .map(|i| SubClone::new(i, capacity))
+            .map(|i| SubClone::new(i as CloneId, capacity))
             .collect();
         let tot_cells = cells.len();
         debug!("assigning {tot_cells} cells to the wild-type clone");
@@ -241,13 +246,17 @@ impl SubClones {
     }
 
     pub fn new_empty() -> Self {
-        SubClones((0..MAX_SUBCLONES).map(SubClone::empty_with_id).collect())
+        SubClones(
+            (0..MAX_SUBCLONES)
+                .map(|i| SubClone::empty_with_id(i as CloneId))
+                .collect(),
+        )
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
         SubClones(
             (0..MAX_SUBCLONES)
-                .map(|id| SubClone::with_capacity(id, capacity))
+                .map(|id| SubClone::with_capacity(id as CloneId, capacity))
                 .collect(),
         )
     }
@@ -256,12 +265,12 @@ impl SubClones {
         self.0.iter().map(|subclone| subclone.cell_count()).sum()
     }
 
-    pub(crate) fn get_clone(&self, id: usize) -> Option<&SubClone> {
-        self.0.get(id)
+    pub(crate) fn get_clone(&self, id: CloneId) -> Option<&SubClone> {
+        self.0.get(id as usize)
     }
 
-    pub(crate) fn get_mut_clone_unchecked(&mut self, id: usize) -> &mut SubClone {
-        &mut self.0[id]
+    pub(crate) fn get_mut_clone_unchecked(&mut self, id: CloneId) -> &mut SubClone {
+        &mut self.0[id as usize]
     }
 
     pub fn get_neutral_clone(&self) -> &SubClone {
@@ -269,7 +278,7 @@ impl SubClones {
     }
 
     pub fn array_of_gillespie_reactions(&self) -> [CloneId; MAX_SUBCLONES] {
-        core::array::from_fn(|i| i)
+        core::array::from_fn(|i| i as CloneId)
     }
 
     pub(crate) fn into_subsampled(self, nb_cells: NonZeroUsize, rng: &mut impl Rng) -> Self {
@@ -298,7 +307,7 @@ impl SubClones {
             })
             .choose_multiple(rng, nb_cells.get())
         {
-            subclones.0[clone_id].cells.push(cell);
+            subclones.0[clone_id as usize].cells.push(cell);
         }
 
         // `parent_id` is preserved for clones that retain at least one cell
@@ -327,7 +336,7 @@ impl SubClones {
             .collect()
     }
 
-    pub(crate) fn get_cells_with_clones_idx(&self) -> Vec<(&StemCell, usize)> {
+    pub(crate) fn get_cells_with_clones_idx(&self) -> Vec<(&StemCell, CloneId)> {
         self.0
             .iter()
             .flat_map(|subclone| subclone.get_cells_subclones_idx())
@@ -338,7 +347,7 @@ impl SubClones {
         &self,
         nb_cells: usize,
         rng: &mut impl Rng,
-    ) -> Vec<(&StemCell, usize)> {
+    ) -> Vec<(&StemCell, CloneId)> {
         self.0
             .iter()
             .flat_map(|subclone| subclone.get_cells_subclones_idx())
@@ -381,7 +390,7 @@ impl Default for SubClones {
         //! Create new subclones each having one cell (this creates also the cells).
         let subclones: Box<[SubClone]> = (0..MAX_SUBCLONES)
             .map(|i| {
-                let mut subclone = SubClone::new(i, 2);
+                let mut subclone = SubClone::new(i as CloneId, 2);
                 subclone.assign_cell(StemCell::new());
                 subclone
             })
@@ -390,8 +399,8 @@ impl Default for SubClones {
     }
 }
 
-impl From<Vec<(StemCell, usize)>> for SubClones {
-    fn from(cells: Vec<(StemCell, usize)>) -> Self {
+impl From<Vec<(StemCell, CloneId)>> for SubClones {
+    fn from(cells: Vec<(StemCell, CloneId)>) -> Self {
         let mut subclones = SubClones::new_empty();
         for (cell, id) in cells.into_iter() {
             subclones.get_mut_clone_unchecked(id).assign_cell(cell);
@@ -474,7 +483,7 @@ impl std::fmt::Display for ParentId {
 pub fn save_variant_phylogeny(subclones: &SubClones, path2file: &Path) -> anyhow::Result<()> {
     let path2file = path2file.with_extension("csv");
     let parent_ids: Vec<ParentId> = (0..MAX_SUBCLONES)
-        .map(|i| ParentId(subclones.get_clone(i).unwrap().get_parent_id()))
+        .map(|i| ParentId(subclones.get_clone(i as CloneId).unwrap().get_parent_id()))
         .collect();
     debug!("variant phylogeny in {path2file:#?}");
     write2file(&parent_ids, &path2file, None, false)?;
@@ -492,9 +501,9 @@ pub fn proliferating_cell(
     //! hence subclones are borrowed mutably.
     trace!(
         "a cell from clone {:#?} will divide",
-        subclones.0[subclone_id]
+        subclones.0[subclone_id as usize]
     );
-    subclones.0[subclone_id]
+    subclones.0[subclone_id as usize]
         .random_cell(rng)
         .with_context(|| "found empty subclone")
         .unwrap()
@@ -511,7 +520,7 @@ mod tests {
     use rand::{rngs::SmallRng, SeedableRng};
 
     #[quickcheck]
-    fn assign_cell_test(id: usize) -> bool {
+    fn assign_cell_test(id: CloneId) -> bool {
         let mut neutral_clone = SubClone {
             cells: vec![],
             id,
@@ -534,7 +543,7 @@ mod tests {
         let number_of_cells = subclones.0[subclone_id as usize].get_cells().len();
         let tot_cells = subclones.compute_tot_cells();
 
-        let _ = proliferating_cell(&mut subclones, subclone_id as usize, &mut rng);
+        let _ = proliferating_cell(&mut subclones, subclone_id as CloneId, &mut rng);
 
         let subclones_have_lost_cell =
             Variants::variant_counts(&subclones).iter().sum::<u64>() < tot_cells;
@@ -587,7 +596,7 @@ mod tests {
         // `parent_id`; clones that lost every cell fall back to the
         // constructor default (`None` for slot 0, `Some(0)` elsewhere).
         for i in 0..MAX_SUBCLONES {
-            let slot = subsampled.get_clone(i).unwrap();
+            let slot = subsampled.get_clone(i as CloneId).unwrap();
             let expected_parent: Option<CloneId> = match i {
                 0 => None,
                 7 if !slot.is_empty() => Some(3),

--- a/src/subclone.rs
+++ b/src/subclone.rs
@@ -282,9 +282,9 @@ impl SubClones {
             subclones.0[clone_id].cells.push(cell);
         }
 
-        // `parent_id` is preserved per slot for clones that retain at least
-        // one cell after subsampling: clones that lost all their cells revert
-        // to default which is the neutral clone.
+        // `parent_id` is preserved for clones that retain at least one cell
+        // after subsampling: clones that lost all their cells revert to default
+        // which is the neutral clone.
         for (i, &pid) in parent_ids.iter().enumerate() {
             if !subclones.0[i].is_empty() {
                 subclones.0[i].parent_id = pid;
@@ -436,6 +436,16 @@ pub fn save_variant_fraction(subclones: &SubClones, path2file: &Path) -> anyhow:
     Ok(())
 }
 
+pub fn save_variant_phylogeny(subclones: &SubClones, path2file: &Path) -> anyhow::Result<()> {
+    let path2file = path2file.with_extension("csv");
+    let parent_ids: Vec<CloneId> = (0..MAX_SUBCLONES)
+        .map(|i| subclones.get_clone(i).unwrap().get_parent_id())
+        .collect();
+    debug!("variant phylogeny in {path2file:#?}");
+    write2file(&parent_ids, &path2file, None, false)?;
+    Ok(())
+}
+
 pub fn proliferating_cell(
     subclones: &mut SubClones,
     subclone_id: CloneId,
@@ -505,6 +515,90 @@ mod tests {
             Variants::variant_fractions(&subclones),
             &[1. / MAX_SUBCLONES as f32; MAX_SUBCLONES]
         );
+    }
+
+    #[test]
+    fn into_subsampled_preserves_parent_id_for_surviving_clones() {
+        // Set up: clone 0 (wild-type), clone 7 with parent_id=0, clone 42
+        // with parent_id=7. Subsample to a size that keeps cells in clones 0
+        // and 7 but is small enough to risk dropping clone 42 — we'll seed
+        // the RNG and verify whichever clones survive carry their parent_id.
+        let mut rng = SmallRng::seed_from_u64(123);
+        let mut subclones = SubClones::new_empty();
+        for _ in 0..20 {
+            subclones
+                .get_mut_clone_unchecked(0)
+                .assign_cell(StemCell::new());
+        }
+        for _ in 0..5 {
+            subclones
+                .get_mut_clone_unchecked(7)
+                .assign_cell(StemCell::new());
+        }
+        for _ in 0..2 {
+            subclones
+                .get_mut_clone_unchecked(42)
+                .assign_cell(StemCell::new());
+        }
+        subclones.get_mut_clone_unchecked(7).set_parent_id(0);
+        subclones.get_mut_clone_unchecked(42).set_parent_id(7);
+
+        let subsampled = subclones.into_subsampled(NonZeroUsize::new(10).unwrap(), &mut rng);
+
+        // Invariant: every clone that retains at least one cell must keep
+        // its parent_id; clones that were fully sampled out reset to 0.
+        for i in 0..MAX_SUBCLONES {
+            let slot = subsampled.get_clone(i).unwrap();
+            let expected_parent = match i {
+                7 if !slot.is_empty() => 0,
+                42 if !slot.is_empty() => 7,
+                _ => 0,
+            };
+            assert_eq!(
+                slot.get_parent_id(),
+                expected_parent,
+                "slot {i} (empty={}) had wrong parent_id",
+                slot.is_empty()
+            );
+        }
+        // At least one of the non-trivial clones should still be alive,
+        // otherwise the test is vacuous.
+        assert!(
+            !subsampled.get_clone(7).unwrap().is_empty()
+                || !subsampled.get_clone(42).unwrap().is_empty(),
+            "subsample dropped both non-neutral clones; test is vacuous"
+        );
+    }
+
+    #[test]
+    fn save_variant_phylogeny_writes_parent_ids() {
+        let mut subclones = SubClones::new_empty();
+        subclones.get_mut_clone_unchecked(7).set_parent_id(3);
+        subclones.get_mut_clone_unchecked(42).set_parent_id(7);
+
+        let path =
+            std::env::temp_dir().join(format!("hsc-phylogeny-test-{}.csv", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        save_variant_phylogeny(&subclones, &path).unwrap();
+
+        let body = std::fs::read_to_string(&path).unwrap();
+        let values: Vec<&str> = body.trim_end_matches(',').split(',').collect();
+        assert_eq!(values.len(), MAX_SUBCLONES);
+        for (i, v) in values.iter().enumerate() {
+            let expected: CloneId = match i {
+                7 => 3,
+                42 => 7,
+                _ => 0,
+            };
+            assert_eq!(
+                v.parse::<CloneId>().unwrap(),
+                expected,
+                "slot {i} mismatched",
+            );
+        }
+
+        std::fs::remove_file(&path).unwrap();
     }
 
     #[quickcheck]

--- a/src/subclone.rs
+++ b/src/subclone.rs
@@ -80,6 +80,16 @@ impl Fitness {
 /// Id of the [`SubClone`]s.
 pub type CloneId = usize;
 
+fn default_parent_id(id: CloneId) -> Option<CloneId> {
+    // wild-type has no parent; every other slot is, by default, a child of
+    // the wild-type clone until a fit-mutation event reassigns it.
+    if id == 0 {
+        None
+    } else {
+        Some(0)
+    }
+}
+
 #[derive(Debug, Clone)]
 /// A group of cells sharing the same genetic background with a specific
 /// proliferation rate.
@@ -92,8 +102,10 @@ pub type CloneId = usize;
 pub struct SubClone {
     cells: Vec<StemCell>,
     pub id: CloneId,
-    // default is the neutral clone with id 0
-    parent_id: CloneId,
+    // `None` only for the wild-type clone (id 0), which has no parent.
+    // Every other clone defaults to `Some(0)`: until a fit-mutation event
+    // overwrites it, the slot is conceptually descended from the wild-type.
+    parent_id: Option<CloneId>,
 }
 
 impl Iterator for SubClone {
@@ -109,7 +121,7 @@ impl SubClone {
         SubClone {
             cells: Vec::with_capacity(cell_capacity),
             id,
-            parent_id: 0,
+            parent_id: default_parent_id(id),
         }
     }
 
@@ -117,7 +129,7 @@ impl SubClone {
         SubClone {
             cells: Vec::with_capacity(capacity),
             id,
-            parent_id: 0,
+            parent_id: default_parent_id(id),
         }
     }
 
@@ -125,7 +137,7 @@ impl SubClone {
         SubClone {
             cells: vec![],
             id,
-            parent_id: 0,
+            parent_id: default_parent_id(id),
         }
     }
 
@@ -145,12 +157,12 @@ impl SubClone {
         self.get_cells().is_empty()
     }
 
-    pub fn get_parent_id(&self) -> CloneId {
+    pub fn get_parent_id(&self) -> Option<CloneId> {
         self.parent_id
     }
 
     pub fn set_parent_id(&mut self, parent_id: CloneId) {
-        self.parent_id = parent_id;
+        self.parent_id = Some(parent_id);
     }
 
     pub fn assign_cell(&mut self, cell: StemCell) {
@@ -204,7 +216,9 @@ pub fn next_clone(
 /// A collection of subclones each having their proliferative advantage.
 /// This collection contains the neutral clone as well.
 #[derive(Clone, Debug)]
-pub struct SubClones([SubClone; MAX_SUBCLONES]);
+// Boxed slice rather than `[SubClone; MAX_SUBCLONES]` to avoid overflow in
+// debug mode.
+pub struct SubClones(Box<[SubClone]>);
 
 impl SubClones {
     pub fn new(cells: Vec<StemCell>, capacity: usize) -> Self {
@@ -213,8 +227,9 @@ impl SubClones {
         //!
         //! All clones have their own `capacity`.
         // initial state
-        let mut subclones: [SubClone; MAX_SUBCLONES] =
-            std::array::from_fn(|i| SubClone::new(i, capacity));
+        let mut subclones: Box<[SubClone]> = (0..MAX_SUBCLONES)
+            .map(|i| SubClone::new(i, capacity))
+            .collect();
         let tot_cells = cells.len();
         debug!("assigning {tot_cells} cells to the wild-type clone");
         for cell in cells {
@@ -226,13 +241,15 @@ impl SubClones {
     }
 
     pub fn new_empty() -> Self {
-        SubClones(std::array::from_fn(SubClone::empty_with_id))
+        SubClones((0..MAX_SUBCLONES).map(SubClone::empty_with_id).collect())
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
-        SubClones(std::array::from_fn(|id| {
-            SubClone::with_capacity(id, capacity)
-        }))
+        SubClones(
+            (0..MAX_SUBCLONES)
+                .map(|id| SubClone::with_capacity(id, capacity))
+                .collect(),
+        )
     }
 
     pub fn compute_tot_cells(&self) -> u64 {
@@ -257,12 +274,14 @@ impl SubClones {
 
     pub(crate) fn into_subsampled(self, nb_cells: NonZeroUsize, rng: &mut impl Rng) -> Self {
         //! Take a subsample of the population that is stored in these subclones.
-        let parent_ids: [CloneId; MAX_SUBCLONES] = std::array::from_fn(|i| self.0[i].parent_id);
+        let parent_ids: [Option<CloneId>; MAX_SUBCLONES] =
+            std::array::from_fn(|i| self.0[i].parent_id);
 
         let mut subclones = Self::new_empty();
 
-        for (cell, clone_id) in self
-            .0
+        // `Box<[T]>::into_iter()` derefs to `[T]` and yields `&T`; round-trip
+        // through `Vec` to consume the slice and get owned `SubClone`s.
+        for (cell, clone_id) in Vec::from(self.0)
             .into_iter()
             .flat_map(|subclone| {
                 // for all subclones get all the cells with the its subclone_id.
@@ -275,7 +294,7 @@ impl SubClones {
                     .cells
                     .into_iter()
                     .map(|cell| (cell, subclone.id))
-                    .collect::<Vec<(StemCell, usize)>>()
+                    .collect::<Vec<(StemCell, CloneId)>>()
             })
             .choose_multiple(rng, nb_cells.get())
         {
@@ -283,8 +302,8 @@ impl SubClones {
         }
 
         // `parent_id` is preserved for clones that retain at least one cell
-        // after subsampling: clones that lost all their cells revert to default
-        // which is the neutral clone.
+        // after subsampling: clones that lost all their cells revert to the
+        // constructor default (`None` for the wild-type, `Some(0)` elsewhere).
         for (i, &pid) in parent_ids.iter().enumerate() {
             if !subclones.0[i].is_empty() {
                 subclones.0[i].parent_id = pid;
@@ -360,11 +379,13 @@ impl SubClones {
 impl Default for SubClones {
     fn default() -> Self {
         //! Create new subclones each having one cell (this creates also the cells).
-        let subclones = std::array::from_fn(|i| {
-            let mut subclone = SubClone::new(i, 2);
-            subclone.assign_cell(StemCell::new());
-            subclone
-        });
+        let subclones: Box<[SubClone]> = (0..MAX_SUBCLONES)
+            .map(|i| {
+                let mut subclone = SubClone::new(i, 2);
+                subclone.assign_cell(StemCell::new());
+                subclone
+            })
+            .collect();
         Self(subclones)
     }
 }
@@ -436,10 +457,24 @@ pub fn save_variant_fraction(subclones: &SubClones, path2file: &Path) -> anyhow:
     Ok(())
 }
 
+/// Display wrapper around `Option<CloneId>` so the value can flow through
+/// [`write2file`]. Serializes as the bare integer for `Some(id)` and the
+/// literal `None` for the wild-type root.
+struct ParentId(Option<CloneId>);
+
+impl std::fmt::Display for ParentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(id) => write!(f, "{id}"),
+            None => write!(f, "None"),
+        }
+    }
+}
+
 pub fn save_variant_phylogeny(subclones: &SubClones, path2file: &Path) -> anyhow::Result<()> {
     let path2file = path2file.with_extension("csv");
-    let parent_ids: Vec<CloneId> = (0..MAX_SUBCLONES)
-        .map(|i| subclones.get_clone(i).unwrap().get_parent_id())
+    let parent_ids: Vec<ParentId> = (0..MAX_SUBCLONES)
+        .map(|i| ParentId(subclones.get_clone(i).unwrap().get_parent_id()))
         .collect();
     debug!("variant phylogeny in {path2file:#?}");
     write2file(&parent_ids, &path2file, None, false)?;
@@ -480,7 +515,7 @@ mod tests {
         let mut neutral_clone = SubClone {
             cells: vec![],
             id,
-            parent_id: 0,
+            parent_id: default_parent_id(id),
         };
         let cell = StemCell::new();
         assert!(neutral_clone.cells.is_empty());
@@ -540,19 +575,24 @@ mod tests {
                 .get_mut_clone_unchecked(42)
                 .assign_cell(StemCell::new());
         }
-        subclones.get_mut_clone_unchecked(7).set_parent_id(0);
+        // Pick non-default `parent_id`s so the surviving-vs-drained
+        // assertion is distinguishable from the constructor default
+        // `Some(0)` that drained slots fall back to.
+        subclones.get_mut_clone_unchecked(7).set_parent_id(3);
         subclones.get_mut_clone_unchecked(42).set_parent_id(7);
 
         let subsampled = subclones.into_subsampled(NonZeroUsize::new(10).unwrap(), &mut rng);
 
-        // Invariant: every clone that retains at least one cell must keep
-        // its parent_id; clones that were fully sampled out reset to 0.
+        // Invariant: clones that retain at least one cell keep their
+        // `parent_id`; clones that lost every cell fall back to the
+        // constructor default (`None` for slot 0, `Some(0)` elsewhere).
         for i in 0..MAX_SUBCLONES {
             let slot = subsampled.get_clone(i).unwrap();
-            let expected_parent = match i {
-                7 if !slot.is_empty() => 0,
-                42 if !slot.is_empty() => 7,
-                _ => 0,
+            let expected_parent: Option<CloneId> = match i {
+                0 => None,
+                7 if !slot.is_empty() => Some(3),
+                42 if !slot.is_empty() => Some(7),
+                _ => Some(0),
             };
             assert_eq!(
                 slot.get_parent_id(),
@@ -586,16 +626,13 @@ mod tests {
         let values: Vec<&str> = body.trim_end_matches(',').split(',').collect();
         assert_eq!(values.len(), MAX_SUBCLONES);
         for (i, v) in values.iter().enumerate() {
-            let expected: CloneId = match i {
-                7 => 3,
-                42 => 7,
-                _ => 0,
+            let expected: &str = match i {
+                0 => "None",
+                7 => "3",
+                42 => "7",
+                _ => "0",
             };
-            assert_eq!(
-                v.parse::<CloneId>().unwrap(),
-                expected,
-                "slot {i} mismatched",
-            );
+            assert_eq!(*v, expected, "slot {i} mismatched");
         }
 
         std::fs::remove_file(&path).unwrap();


### PR DESCRIPTION
## Summary
  - Add a `parent_id: CloneId` field to `SubClone`. When a fit-mutation event routes a daughter cell into a previously-empty clone slot, the dividing clone's id is recorded as the new slot's `parent_id`. `parent_id` is also preserved across `SubClones::into_subsampled` for slots that retain at least one cell.
  - Persist the per-clone lineage to disk under a new `<NbCells>cells/variant_phylogeny/<time>years/<idx>.csv` folder, mirroring `variant_fraction`. Opt-in via `--stats
  variant-phylogeny`.
  - When the snapshot is a subsample, `variant_phylogeny` deliberately reflects the full-population lineage. As `parent_id` is a clone-level property, subsampling cells does not change ancestry and we can have `variant_phylogeny[i] != 0` even when `variant_fractions[i] = 0`, documented in `output.md`.

  ## Test plan
  - [x] `cargo build --release`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --locked --all-features --all-targets` (38 lib tests + 1 main test)
  - [x] `cargo test --locked --all-features --doc`
  - [x] New unit tests: `parent_id_set_on_new_variant`, `parent_id_untouched_without_new_variant`, `into_subsampled_preserves_parent_id_for_surviving_clones`,
  `save_variant_phylogeny_writes_parent_ids`
  - [x] CLI smoke run: `hsc /tmp/hsc-phylo --stats variant-phylogeny,variants moran` produces `variant_phylogeny/<time>/<idx>.csv` alongside `variant_fraction/`; CSV has exactly
  `MAX_SUBCLONES=3000` integer entries with non-zero `parent_id`s for each clone that received a fit-mutation cell.
  - [x] Save-time subsampling verified: full-population CSV (`100cells/.../<time>/<idx>.csv`) and subsample CSV (`30cells/.../<time>/<idx>.csv`) at the same simulation time are
  byte-identical when both are written by `--save-population --subsamples=30 --snapshots=8`.
