### PR TITLE
Squeeze clone id into u16

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -258,7 +258,7 @@ impl Moran {
         // remove a cell from a random subclone based on the frequencies of
         // the clones at the current state
         let variants = Variants::variant_counts(&self.subclones);
-        let id2remove = WeightedIndex::new(variants).unwrap().sample(rng);
+        let id2remove = WeightedIndex::new(variants).unwrap().sample(rng) as CloneId;
         let _ = self
             .subclones
             .get_mut_clone_unchecked(id2remove)

--- a/src/process.rs
+++ b/src/process.rs
@@ -668,7 +668,8 @@ mod tests {
         //!
         //! **warning** this is very slow.
         let tot_cells = subclones.compute_tot_cells();
-        (0..MAX_SUBCLONES).find(|&id| subclones.get_clone(id).unwrap().cell_count() == tot_cells)
+        (0..MAX_SUBCLONES as CloneId)
+            .find(|&id| subclones.get_clone(id).unwrap().cell_count() == tot_cells)
     }
 
     #[quickcheck]

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -15,7 +15,7 @@ use log::debug;
 use crate::{
     genotype::{MutationalBurden, Sfs, SingleCellMutations},
     stemcell::StemCell,
-    subclone::{save_variant_fraction, SubClones},
+    subclone::{save_variant_fraction, CloneId, SubClones},
 };
 
 /// The statistics/measurements we want to save from the simulations.
@@ -107,7 +107,7 @@ pub(crate) fn save_it(
     path2dir: &Path,
     filename: &Path,
     time: f32,
-    cells_with_idx: Vec<(&StemCell, usize)>,
+    cells_with_idx: Vec<(&StemCell, CloneId)>,
     stats: &StatsConfig,
 ) -> anyhow::Result<()> {
     debug!("saving data at time {time}");
@@ -179,7 +179,7 @@ pub(crate) fn save_it(
                 cells_with_idx
                     .into_iter()
                     .map(|(cell, id)| (cell.to_owned(), id))
-                    .collect::<Vec<(StemCell, usize)>>(),
+                    .collect::<Vec<(StemCell, CloneId)>>(),
             ),
             &make_path(
                 path2dir,

--- a/src/subclone.rs
+++ b/src/subclone.rs
@@ -78,7 +78,7 @@ impl Fitness {
 }
 
 /// Id of the [`SubClone`]s.
-pub type CloneId = usize;
+pub type CloneId = u16;
 
 #[derive(Debug, Clone)]
 /// A group of cells sharing the same genetic background with a specific
@@ -167,14 +167,14 @@ pub fn next_clone(
     // this will panic when u is not small and the cell hasn't divided much,
     // i.e. when p > 1
     if Bernoulli::new(p).unwrap().sample(rng) {
-        let mut rnd_clone_id = rng.random_range(0..MAX_SUBCLONES);
+        let mut rnd_clone_id = rng.random_range(0..MAX_SUBCLONES as CloneId);
         let mut counter = 0;
         // the new random clone cannot have `subclone_id` id and must be empty
         while (rnd_clone_id == old_subclone_id
             || !subclones.get_clone(rnd_clone_id).unwrap().is_empty())
             && counter <= MAX_SUBCLONES
         {
-            rnd_clone_id = rng.random_range(0..MAX_SUBCLONES);
+            rnd_clone_id = rng.random_range(0..MAX_SUBCLONES as CloneId);
             counter += 1;
         }
         assert!(counter <= MAX_SUBCLONES, "max number of clones reached");
@@ -198,7 +198,7 @@ impl SubClones {
         //! All clones have their own `capacity`.
         // initial state
         let mut subclones: [SubClone; MAX_SUBCLONES] =
-            std::array::from_fn(|i| SubClone::new(i, capacity));
+            std::array::from_fn(|i| SubClone::new(i as CloneId, capacity));
         let tot_cells = cells.len();
         debug!("assigning {tot_cells} cells to the wild-type clone");
         for cell in cells {
@@ -210,12 +210,14 @@ impl SubClones {
     }
 
     pub fn new_empty() -> Self {
-        SubClones(std::array::from_fn(SubClone::empty_with_id))
+        SubClones(std::array::from_fn(|i| {
+            SubClone::empty_with_id(i as CloneId)
+        }))
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
         SubClones(std::array::from_fn(|id| {
-            SubClone::with_capacity(id, capacity)
+            SubClone::with_capacity(id as CloneId, capacity)
         }))
     }
 
@@ -224,11 +226,11 @@ impl SubClones {
     }
 
     pub(crate) fn get_clone(&self, id: CloneId) -> Option<&SubClone> {
-        self.0.get(id)
+        self.0.get(id as usize)
     }
 
     pub(crate) fn get_mut_clone_unchecked(&mut self, id: CloneId) -> &mut SubClone {
-        &mut self.0[id]
+        &mut self.0[id as usize]
     }
 
     pub fn get_neutral_clone(&self) -> &SubClone {
@@ -236,7 +238,7 @@ impl SubClones {
     }
 
     pub fn array_of_gillespie_reactions(&self) -> [CloneId; MAX_SUBCLONES] {
-        core::array::from_fn(|i| i)
+        core::array::from_fn(|i| i as CloneId)
     }
 
     pub(crate) fn into_subsampled(self, nb_cells: NonZeroUsize, rng: &mut impl Rng) -> Self {
@@ -261,7 +263,7 @@ impl SubClones {
             })
             .choose_multiple(rng, nb_cells.get())
         {
-            subclones.0[clone_id].cells.push(cell);
+            subclones.0[clone_id as usize].cells.push(cell);
         }
         subclones
     }
@@ -333,7 +335,7 @@ impl Default for SubClones {
     fn default() -> Self {
         //! Create new subclones each having one cell (this creates also the cells).
         let subclones = std::array::from_fn(|i| {
-            let mut subclone = SubClone::new(i, 2);
+            let mut subclone = SubClone::new(i as CloneId, 2);
             subclone.assign_cell(StemCell::new());
             subclone
         });
@@ -419,9 +421,9 @@ pub fn proliferating_cell(
     //! hence subclones are borrowed mutably.
     trace!(
         "a cell from clone {:#?} will divide",
-        subclones.0[subclone_id]
+        subclones.0[subclone_id as usize]
     );
-    subclones.0[subclone_id]
+    subclones.0[subclone_id as usize]
         .random_cell(rng)
         .with_context(|| "found empty subclone")
         .unwrap()
@@ -454,7 +456,7 @@ mod tests {
         if subclone_id >= subclones.0.len() as u8 {
             subclone_id = 1;
         }
-        let number_of_cells = subclones.0[subclone_id as CloneId].get_cells().len();
+        let number_of_cells = subclones.0[subclone_id as usize].get_cells().len();
         let tot_cells = subclones.compute_tot_cells();
 
         let _ = proliferating_cell(&mut subclones, subclone_id as CloneId, &mut rng);
@@ -462,7 +464,7 @@ mod tests {
         let subclones_have_lost_cell =
             Variants::variant_counts(&subclones).iter().sum::<u64>() < tot_cells;
         let subclone_has_lost_cell =
-            subclones.0[subclone_id as CloneId].get_cells().len() == number_of_cells - 1;
+            subclones.0[subclone_id as usize].get_cells().len() == number_of_cells - 1;
         subclones_have_lost_cell && subclone_has_lost_cell
     }
 

--- a/src/subclone.rs
+++ b/src/subclone.rs
@@ -110,14 +110,14 @@ impl SubClone {
         }
     }
 
-    pub fn with_capacity(id: usize, capacity: usize) -> SubClone {
+    pub fn with_capacity(id: CloneId, capacity: usize) -> SubClone {
         SubClone {
             cells: Vec::with_capacity(capacity),
             id,
         }
     }
 
-    pub fn empty_with_id(id: usize) -> SubClone {
+    pub fn empty_with_id(id: CloneId) -> SubClone {
         SubClone { cells: vec![], id }
     }
 
@@ -129,7 +129,7 @@ impl SubClone {
         &self.cells
     }
 
-    pub fn get_cells_subclones_idx(&self) -> Vec<(&StemCell, usize)> {
+    pub fn get_cells_subclones_idx(&self) -> Vec<(&StemCell, CloneId)> {
         self.cells.iter().map(|cell| (cell, self.id)).collect()
     }
 
@@ -223,11 +223,11 @@ impl SubClones {
         self.0.iter().map(|subclone| subclone.cell_count()).sum()
     }
 
-    pub(crate) fn get_clone(&self, id: usize) -> Option<&SubClone> {
+    pub(crate) fn get_clone(&self, id: CloneId) -> Option<&SubClone> {
         self.0.get(id)
     }
 
-    pub(crate) fn get_mut_clone_unchecked(&mut self, id: usize) -> &mut SubClone {
+    pub(crate) fn get_mut_clone_unchecked(&mut self, id: CloneId) -> &mut SubClone {
         &mut self.0[id]
     }
 
@@ -257,7 +257,7 @@ impl SubClones {
                     .cells
                     .into_iter()
                     .map(|cell| (cell, subclone.id))
-                    .collect::<Vec<(StemCell, usize)>>()
+                    .collect::<Vec<(StemCell, CloneId)>>()
             })
             .choose_multiple(rng, nb_cells.get())
         {
@@ -280,7 +280,7 @@ impl SubClones {
             .collect()
     }
 
-    pub(crate) fn get_cells_with_clones_idx(&self) -> Vec<(&StemCell, usize)> {
+    pub(crate) fn get_cells_with_clones_idx(&self) -> Vec<(&StemCell, CloneId)> {
         self.0
             .iter()
             .flat_map(|subclone| subclone.get_cells_subclones_idx())
@@ -291,7 +291,7 @@ impl SubClones {
         &self,
         nb_cells: usize,
         rng: &mut impl Rng,
-    ) -> Vec<(&StemCell, usize)> {
+    ) -> Vec<(&StemCell, CloneId)> {
         self.0
             .iter()
             .flat_map(|subclone| subclone.get_cells_subclones_idx())
@@ -341,8 +341,8 @@ impl Default for SubClones {
     }
 }
 
-impl From<Vec<(StemCell, usize)>> for SubClones {
-    fn from(cells: Vec<(StemCell, usize)>) -> Self {
+impl From<Vec<(StemCell, CloneId)>> for SubClones {
+    fn from(cells: Vec<(StemCell, CloneId)>) -> Self {
         let mut subclones = SubClones::new_empty();
         for (cell, id) in cells.into_iter() {
             subclones.get_mut_clone_unchecked(id).assign_cell(cell);
@@ -438,7 +438,7 @@ mod tests {
     use rand::{rngs::SmallRng, SeedableRng};
 
     #[quickcheck]
-    fn assign_cell_test(id: usize) -> bool {
+    fn assign_cell_test(id: CloneId) -> bool {
         let mut neutral_clone = SubClone { cells: vec![], id };
         let cell = StemCell::new();
         assert!(neutral_clone.cells.is_empty());
@@ -454,15 +454,15 @@ mod tests {
         if subclone_id >= subclones.0.len() as u8 {
             subclone_id = 1;
         }
-        let number_of_cells = subclones.0[subclone_id as usize].get_cells().len();
+        let number_of_cells = subclones.0[subclone_id as CloneId].get_cells().len();
         let tot_cells = subclones.compute_tot_cells();
 
-        let _ = proliferating_cell(&mut subclones, subclone_id as usize, &mut rng);
+        let _ = proliferating_cell(&mut subclones, subclone_id as CloneId, &mut rng);
 
         let subclones_have_lost_cell =
             Variants::variant_counts(&subclones).iter().sum::<u64>() < tot_cells;
         let subclone_has_lost_cell =
-            subclones.0[subclone_id as usize].get_cells().len() == number_of_cells - 1;
+            subclones.0[subclone_id as CloneId].get_cells().len() == number_of_cells - 1;
         subclones_have_lost_cell && subclone_has_lost_cell
     }
 


### PR DESCRIPTION
  ## Summary

  - Flips `pub type CloneId = usize` to `pub type CloneId = u16` in `src/subclone.rs`. Note that `MAX_SUBCLONES` and `CloneId` are related, because `CloneId` are used to index the array of reaction `(0..MAX_SUBCLONES)`, but `MAX_SUBCLONES = 3000` fits comfortably under `u16::MAX = 65535`.
  - Adds the narrowing/widening casts the alias change makes mandatory: `as usize` where a `CloneId` indexes the `[SubClone; MAX_SUBCLONES]` array, `as CloneId` where a `usize`
  iterator or sampler flows into a clone-id position.
  - No behavior change — the values, RNG stream, and order of operations are identical.

  ## Memory impact

  - `[CloneId; MAX_SUBCLONES]` (the Gillespie-reactions array materialised for every `sosa::simulate` call): **24 KB → 6 KB**.
  - `SubClone::id`: **8 B → 2 B** per clone (~18 KB across `SubClones`).
  - Every `(StemCell, CloneId)` tuple that crosses through `snapshots.rs` shrinks by 6 B per cell.

  ## Notes

  - `sosa` (v4.0.0) is compatible — `AdvanceStep::Reaction` only requires `Debug + Copy`, both of which `u16` satisfies. The `NextReaction { event: 0, .. }` literals in tests infer
  to `u16` cleanly.
  - `MAX_SUBCLONES` stays `usize` (used as the const generic in `AdvanceStep<MAX_SUBCLONES>`).
  - This builds on the prep commit `5dd2909a2` (already on `master`) which replaced raw `usize` with `CloneId` on the API surfaces, making the alias flip mechanical.

  ## Test plan

  - [x] `cargo build --all-targets`
  - [x] `cargo clippy --all-targets --all-features -- -D warnings`
  - [x] `cargo test --locked --all-features --all-targets` — 35 unit/integration + 1 main test pass
  - [x] `cargo test --locked --all-features --doc` — 2 doc tests pass
