### PR TITLE
Add parent subclones variant phylogeny

### DIFF
--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -27,6 +27,7 @@ pub enum Stats {
     Burden,
     ScBurden,
     Variants,
+    VariantsPhylogeny,
 }
 
 impl From<Stats> for Stats2Save {
@@ -36,6 +37,7 @@ impl From<Stats> for Stats2Save {
             Stats::Sfs => Stats2Save::Sfs,
             Stats::ScBurden => Stats2Save::SingleCellMutations,
             Stats::Variants => Stats2Save::VariantFraction,
+            Stats::VariantsPhylogeny => Stats2Save::VariantsPhylogeny,
         }
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -291,6 +291,7 @@ impl Moran {
                 &self.filename,
                 time,
                 population,
+                &self.subclones,
                 &self.stats,
             )
             .with_context(|| "cannot save the full population")
@@ -305,6 +306,7 @@ impl Moran {
                         &self.filename,
                         time,
                         population,
+                        &self.subclones,
                         &self.stats,
                     )
                     .with_context(|| "cannot save the full population")
@@ -319,6 +321,7 @@ impl Moran {
                     &self.filename,
                     time,
                     cells_with_idx,
+                    &self.subclones,
                     &self.stats,
                 )
                 .with_context(|| "cannot save the subsample")

--- a/src/proliferation.rs
+++ b/src/proliferation.rs
@@ -81,6 +81,11 @@ impl Proliferation {
                 .unwrap()) as f64;
         // the fit variant is sampled here
         let clone_id = next_clone(subclones, proliferating_subclone, p, rng);
+        if clone_id != proliferating_subclone {
+            subclones
+                .get_mut_clone_unchecked(clone_id)
+                .set_parent_id(proliferating_subclone);
+        }
         debug!("proliferation at time {time}");
         debug!(
             "cell with last division time {} is dividing",
@@ -227,6 +232,66 @@ mod tests {
             .map(|c| c.burden())
             .sum();
         assert!(total > 0);
+    }
+
+    #[test]
+    fn proliferate_sets_parent_id_on_new_clone() {
+        // p = u * interdivision_time. With mu near cells and a unit
+        // interdivision time, the Bernoulli draw in next_clone returns true
+        // with overwhelming probability, so within a few iterations at least
+        // one new fit clone is born; its parent_id must equal the proliferating
+        // clone's id, and the wild-type clone must stay parentless.
+        let rng = &mut ChaCha8Rng::seed_from_u64(42);
+        let mut subclones = make_subclones(5, 0.0);
+        let distributions = Distributions::new(Probs::new(50., 50., 99., 0., 100));
+        let proliferation = Proliferation::new(NeutralMutations::UponDivision, Division::Symmetric);
+
+        let mut saw_birth = false;
+        for _ in 0..10 {
+            // Bring all cells back to t=0 so interdivision_time stays at 1.0
+            // each iteration and p stays close to 1.
+            for cell in subclones.get_mut_cells() {
+                cell.set_last_division_time(0.0).unwrap();
+            }
+            proliferation.proliferate(&mut subclones, 1.0, 0, &distributions, rng);
+            let births: Vec<CloneId> = (1..crate::MAX_SUBCLONES as CloneId)
+                .filter(|id| !subclones.get_clone(*id).unwrap().is_empty())
+                .collect();
+            if let Some(&new_id) = births.first() {
+                assert_eq!(
+                    subclones.get_clone(new_id).unwrap().parent_id(),
+                    Some(0_u16),
+                );
+                saw_birth = true;
+                break;
+            }
+        }
+        assert!(saw_birth, "no new fit clone born across 10 proliferations");
+        // Wild type stays parentless.
+        assert!(subclones.get_clone(0).unwrap().parent_id().is_none());
+    }
+
+    #[test]
+    fn proliferate_leaves_parent_id_none_when_no_new_clone() {
+        // With u = 0 next_clone never reassigns; no parent_id should be set.
+        let rng = &mut ChaCha8Rng::seed_from_u64(42);
+        let mut subclones = make_subclones(5, 0.0);
+        let distributions = Distributions::new(Probs::new(50., 50., 0., 0., 100));
+        let proliferation = Proliferation::new(NeutralMutations::UponDivision, Division::Symmetric);
+
+        for _ in 0..10 {
+            proliferation.proliferate(&mut subclones, 1.0, 0, &distributions, rng);
+        }
+
+        for id in 0..crate::MAX_SUBCLONES as CloneId {
+            let clone = subclones.get_clone(id).unwrap();
+            assert!(
+                clone.parent_id().is_none(),
+                "clone {} unexpectedly has parent {:?}",
+                clone.id,
+                clone.parent_id()
+            );
+        }
     }
 
     #[test]

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -15,7 +15,7 @@ use log::debug;
 use crate::{
     genotype::{MutationalBurden, Sfs, SingleCellMutations},
     stemcell::StemCell,
-    subclone::{CloneId, SubClones, save_variant_fraction},
+    subclone::{CloneId, SubClones, save_phylogeny, save_variant_fraction},
 };
 
 /// The statistics/measurements we want to save from the simulations.
@@ -25,6 +25,7 @@ pub enum Stats2Save {
     Sfs,
     VariantFraction,
     SingleCellMutations,
+    VariantsPhylogeny,
 }
 
 /// Specify whether to save the whole population or a subsampling.
@@ -94,6 +95,7 @@ fn make_path(
         Stats2Save::VariantFraction => path2dir.join("variant_fraction"),
         Stats2Save::Burden => path2dir.join("burden"),
         Stats2Save::Sfs => path2dir.join("sfs"),
+        Stats2Save::VariantsPhylogeny => path2dir.join("variant_phylogeny"),
     };
     let path2file = path2file.join(timepoint);
 
@@ -108,6 +110,7 @@ pub(crate) fn save_it(
     filename: &Path,
     time: f32,
     cells_with_idx: Vec<(&StemCell, CloneId)>,
+    subclones: &SubClones,
     stats: &StatsConfig,
 ) -> anyhow::Result<()> {
     debug!("saving data at time {time}");
@@ -191,5 +194,70 @@ pub(crate) fn save_it(
         )?;
     }
 
+    if stats.enabled.contains(Stats2Save::VariantsPhylogeny) {
+        save_phylogeny(
+            subclones,
+            &make_path(
+                path2dir,
+                filename,
+                Stats2Save::VariantsPhylogeny,
+                nb_cells,
+                time,
+            )?,
+        )?;
+    }
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MAX_SUBCLONES;
+
+    fn unique_tmpdir(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "hsc-test-{name}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id(),
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn save_it_emits_phylogeny_when_enabled() {
+        let dir = unique_tmpdir("save_it_phylogeny");
+        let filename = PathBuf::from("0");
+        let mut subclones = SubClones::new(vec![StemCell::new()], 4);
+        subclones.get_mut_clone_unchecked(3).set_parent_id(1);
+
+        let cells_with_idx = subclones.get_cells_with_clones_idx();
+        let nb_cells = cells_with_idx.len();
+
+        let stats = StatsConfig {
+            enabled: EnumSet::only(Stats2Save::VariantsPhylogeny),
+        };
+
+        save_it(&dir, &filename, 0.0, cells_with_idx, &subclones, &stats).unwrap();
+
+        let csv = dir
+            .join(format!("{nb_cells}cells"))
+            .join("variant_phylogeny")
+            .join("0dot0years")
+            .join("0.csv");
+        assert!(csv.exists(), "expected {csv:?}");
+        let content = std::fs::read_to_string(&csv).unwrap();
+        let fields: Vec<&str> = content
+            .strip_suffix(',')
+            .unwrap_or(&content)
+            .split(',')
+            .collect();
+        assert_eq!(fields.len(), MAX_SUBCLONES);
+        assert_eq!(fields[0], "");
+        assert_eq!(fields[3], "1");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src/subclone.rs
+++ b/src/subclone.rs
@@ -81,6 +81,23 @@ impl Fitness {
 /// Id of the [`SubClone`]s.
 pub type CloneId = u16;
 
+/// Display wrapper for a subclone's optional parent.
+///
+/// `Some(p)` formats as the integer `p`, `None` formats as the empty string
+/// (read as `NaN` by pandas and other CSV readers). The `:.6` precision
+/// specifier used by [`crate::write2file`] is silently ignored.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ParentId(pub(crate) Option<CloneId>);
+
+impl std::fmt::Display for ParentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(p) => write!(f, "{p}"),
+            None => Ok(()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 /// A group of cells sharing the same genetic background with a specific
 /// proliferation rate.
@@ -415,11 +432,26 @@ impl Variants {
     }
 }
 
-pub fn save_variant_fraction(subclones: &SubClones, path2file: &Path) -> anyhow::Result<()> {
+pub(crate) fn save_variant_fraction(subclones: &SubClones, path2file: &Path) -> anyhow::Result<()> {
     let path2file = path2file.with_extension("csv");
     let total_variant_frac = Variants::variant_fractions(subclones);
     debug!("total variant fraction in {path2file:#?}");
     write2file(&total_variant_frac, &path2file, None, false)?;
+    Ok(())
+}
+
+pub(crate) fn save_phylogeny(subclones: &SubClones, path2file: &Path) -> anyhow::Result<()> {
+    //! Save the per-clone parent-id row for the current `subclones` state.
+    //!
+    //! Emits a dense row of `MAX_SUBCLONES` comma-separated entries; clones
+    //! without a parent (the wild type and any never-born slot) appear as
+    //! empty fields.
+    let path2file = path2file.with_extension("csv");
+    let row: Vec<ParentId> = (0..MAX_SUBCLONES as CloneId)
+        .map(|id| ParentId(subclones.get_clone(id).unwrap().parent_id()))
+        .collect();
+    debug!("phylogeny in {path2file:#?}");
+    write2file(&row, &path2file, None, false)?;
     Ok(())
 }
 
@@ -576,6 +608,60 @@ mod tests {
         for clone in rebuilt.0.iter() {
             assert!(clone.parent_id().is_none());
         }
+    }
+
+    #[test]
+    fn parent_id_display_format() {
+        // None -> empty string; Some -> integer; the `:.6` precision specifier
+        // used by write2file is silently ignored for our Display impl.
+        assert_eq!(format!("{}", ParentId(None)), "");
+        assert_eq!(format!("{}", ParentId(Some(42))), "42");
+        assert_eq!(format!("{:.6}", ParentId(None)), "");
+        assert_eq!(format!("{:.6}", ParentId(Some(42))), "42");
+    }
+
+    fn unique_tmpdir(name: &str) -> std::path::PathBuf {
+        // Per-test unique directory under the system temp dir, cleaned at the
+        // start of the test (best-effort) so reruns start fresh.
+        let path = std::env::temp_dir().join(format!(
+            "hsc-test-{name}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id(),
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn save_phylogeny_writes_dense_row() {
+        let dir = unique_tmpdir("save_phylogeny");
+        let path = dir.join("row.csv");
+        let mut subclones = SubClones::new(vec![StemCell::new()], 4);
+        subclones.get_mut_clone_unchecked(2).set_parent_id(0);
+        subclones.get_mut_clone_unchecked(7).set_parent_id(2);
+
+        save_phylogeny(&subclones, &path).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let fields: Vec<&str> = content
+            .strip_suffix(',')
+            .unwrap_or(&content)
+            .split(',')
+            .collect();
+        assert_eq!(fields.len(), MAX_SUBCLONES);
+        assert_eq!(fields[0], ""); // wild-type root
+        assert_eq!(fields[1], "");
+        assert_eq!(fields[2], "0");
+        assert_eq!(fields[7], "2");
+        // every other slot stayed at None -> empty
+        for (i, f) in fields.iter().enumerate() {
+            if i != 2 && i != 7 {
+                assert!(f.is_empty(), "slot {i} expected empty, got {f:?}");
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[quickcheck]

--- a/src/subclone.rs
+++ b/src/subclone.rs
@@ -81,7 +81,7 @@ impl Fitness {
 /// Id of the [`SubClone`]s.
 pub type CloneId = u16;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 /// A group of cells sharing the same genetic background with a specific
 /// proliferation rate.
 ///
@@ -93,6 +93,7 @@ pub type CloneId = u16;
 pub struct SubClone {
     cells: Vec<StemCell>,
     pub id: CloneId,
+    parent_id: Option<CloneId>,
 }
 
 impl Iterator for SubClone {
@@ -108,6 +109,7 @@ impl SubClone {
         SubClone {
             cells: Vec::with_capacity(cell_capacity),
             id,
+            parent_id: None,
         }
     }
 
@@ -115,11 +117,24 @@ impl SubClone {
         SubClone {
             cells: Vec::with_capacity(capacity),
             id,
+            parent_id: None,
         }
     }
 
     pub fn empty_with_id(id: CloneId) -> SubClone {
-        SubClone { cells: vec![], id }
+        SubClone {
+            cells: vec![],
+            id,
+            parent_id: None,
+        }
+    }
+
+    pub fn parent_id(&self) -> Option<CloneId> {
+        self.parent_id
+    }
+
+    pub(crate) fn set_parent_id(&mut self, parent: CloneId) {
+        self.parent_id = Some(parent);
     }
 
     pub fn get_mut_cells(&mut self) -> &mut [StemCell] {
@@ -437,14 +452,14 @@ mod tests {
     use quickcheck_macros::quickcheck;
     use rand::{SeedableRng, rngs::SmallRng};
 
-    #[quickcheck]
-    fn assign_cell_test(id: CloneId) -> bool {
-        let mut neutral_clone = SubClone { cells: vec![], id };
+    #[test]
+    fn assign_cell_test() {
+        let mut neutral_clone = SubClone::default();
         let cell = StemCell::new();
         assert!(neutral_clone.cells.is_empty());
 
         neutral_clone.assign_cell(cell);
-        !neutral_clone.cells.is_empty()
+        assert!(!neutral_clone.cells.is_empty());
     }
 
     #[quickcheck]
@@ -513,6 +528,54 @@ mod tests {
         cell.set_last_division_time(1.).unwrap();
 
         next_clone(&subclones, 0, 1., &mut rng);
+    }
+
+    #[test]
+    fn parent_id_defaults_to_none_on_all_constructors() {
+        assert!(SubClone::default().parent_id().is_none());
+        assert!(SubClone::new(7, 4).parent_id().is_none());
+        assert!(SubClone::with_capacity(11, 4).parent_id().is_none());
+        assert!(SubClone::empty_with_id(13).parent_id().is_none());
+
+        for clone in SubClones::new(vec![StemCell::new()], 4).0.iter() {
+            assert!(clone.parent_id().is_none());
+        }
+        for clone in SubClones::new_empty().0.iter() {
+            assert!(clone.parent_id().is_none());
+        }
+        for clone in SubClones::with_capacity(4).0.iter() {
+            assert!(clone.parent_id().is_none());
+        }
+        for clone in SubClones::default().0.iter() {
+            assert!(clone.parent_id().is_none());
+        }
+    }
+
+    #[test]
+    fn parent_id_resets_on_subsample_and_from() {
+        // Build a SubClones, set a parent_id, then run the reconstruction
+        // helpers and confirm the parent state is reset.
+        let mut subclones = SubClones::new(vec![StemCell::new(); 4], 4);
+        subclones.get_mut_clone_unchecked(2).set_parent_id(0);
+        assert_eq!(subclones.get_clone(2).unwrap().parent_id(), Some(0));
+
+        let mut rng = SmallRng::seed_from_u64(42);
+        let resampled = subclones
+            .clone()
+            .into_subsampled(NonZeroUsize::new(2).unwrap(), &mut rng);
+        for clone in resampled.0.iter() {
+            assert!(clone.parent_id().is_none());
+        }
+
+        let cells: Vec<(StemCell, CloneId)> = subclones
+            .0
+            .iter()
+            .flat_map(|s| s.get_cells().iter().map(move |c| (c.clone(), s.id)))
+            .collect();
+        let rebuilt = SubClones::from(cells);
+        for clone in rebuilt.0.iter() {
+            assert!(clone.parent_id().is_none());
+        }
     }
 
     #[quickcheck]


### PR DESCRIPTION
## Summary

Track subclone lineages.

Two commits:
1. **introduce new private attribute `parent_id` in `SubClone`**. In each `SubClone` the new `parent_id: Option<CloneId>` field in `SubClone` refers to the `CloneId` of the parent. The wild-type clone has `parent_id` set to `None`, whereas all the other clones are initiated with `Some(0)`, has all clones originate from the wild-type clone, which has `CloneId` of `0`. As cells get assigned to new clones in `Proliferation::proliferate`, we update the `parent_id`.
2. **save clone phylogeny to `variant_phylogeny/<t>/<idx>.csv`**. New `--stats variants-phylogeny` CLI value. Every snapshot saves `MAX_SUBCLONES` parent ids by mapping:
     - `Some(p)` → integer `p`
     - `None` → empty field (read as `NaN` by pandas/polars/R/duckdb)
by leveraging a newtype for `parent_id` that implements `Display`

## Output layout
Cross-checking the two files at the same <t> lets you intersect "who's alive" with "who's whose child". A position with a non-zero variant_fraction and a Some(p) variant_phylogeny entry is a currently-alive non-root clone with parent p; a position with empty variant_phylogeny but non-zero variant_fraction only ever happens for the wild type (id 0).

  Test plan
  - cargo test --locked --all-features --doc
  - Smoke run: cargo run --release -- --stats sfs,variants,variants-phylogeny /tmp/hsc-phylo moran
    - variant_phylogeny/ appears alongside variant_fraction/ and sfs/
    - Row has 3000 fields; field 0 (wild type) is empty
    - Non-empty positions match clones with cells (or extinct lineages, which is by design)
    - Multi-level lineage works: e.g. observed pos 1352 -> parent 1368 -> parent 0

  New tests
  - parent_id_defaults_to_none_on_all_constructors
  - parent_id_resets_on_subsample_and_from
  - proliferate_sets_parent_id_on_new_clone
  - proliferate_leaves_parent_id_none_when_no_new_clone
  - parent_id_display_format
  - save_phylogeny_writes_dense_row
  - save_it_emits_phylogeny_when_enabled

  Notes
  - save_variant_fraction visibility tightened from pub → pub(crate) for consistency with the new save_phylogeny (neither is called outside the crate).
  - SubClones::from(...) and into_subsampled reconstruct fresh slots, so parent_id resets to None on those paths — fine because phylogeny is read from the live SubClones before any
  subsampling reconstruction.
